### PR TITLE
Close stdin

### DIFF
--- a/exercises/mongod/exercise.js
+++ b/exercises/mongod/exercise.js
@@ -26,7 +26,7 @@ exercise.addProcessor(function(mode, cb) {
     }
 
     cb(null, !!vers)
-  }.bind(this))
+  }.bind(this)).stdin.end()
 })
 
 module.exports = exercise


### PR DESCRIPTION
Ensures exec doesn't hang waiting for stdin file descriptor to close.

Solves following use case:

`mongod.sh` : 

``` sh
#!/usr/bin/env bash

docker run -i -p 27017:27017 --rm --entrypoint=mongod mongo $@
```

`$ ln -s $PWD/mongod.sh /bin/mongod`

If you don't close stdin, then `learnyoumongo verify` will hang indefinitely.
