### PR TITLE
COUNT: Prevent 0 matches.

### DIFF
--- a/exercises/count/exercise.js
+++ b/exercises/count/exercise.js
@@ -15,7 +15,7 @@ var db, url = 'mongodb://localhost:27017/learnyoumongo'
 exercise.addSetup(function(mode, cb) {
   var self = this
   var numbers = [1, 3, 10]
-  var number = numbers[Math.floor(Math.random() * numbers.length)]
+  var number = numbers[Math.floor(Math.random() * (numbers.length-1))]
   this.submissionArgs = [number]
   this.solutionArgs = [number]
   mongo.connect(url, function(err, _db) {
@@ -24,13 +24,13 @@ exercise.addSetup(function(mode, cb) {
     col = db.collection('parrots')
     col.insert([{
       name: 'Fred'
-    , age: 1
+    , age: numbers[0]
     }, {
       name: 'Jane'
-    , age: 3
+    , age: numbers[1]
     }, {
       name: 'Jenny'
-    , age: 10
+    , age: numbers[2]
     }], cb)
   })
 })


### PR DESCRIPTION
0 matches on COUNT results in incorrect solutions passing. If the query returns an empty set, there is no way to verify if the solution was correct or if they are querying the wrong db/collection.
