### PR TITLE
Added hint on what process.argv is for

### DIFF
--- a/exercises/find/problem.md
+++ b/exercises/find/problem.md
@@ -26,7 +26,7 @@ To find a document or documents, one needs to call `find()` on the collection.
 
 Find is a little bit different than what we are used to seeing.
 
-Keep in mind, `process.argv` is an array of strings. To convert to an integer, you could use parseInt()
+To access the arguments you can use the `process.argv` array of strings (the first argument is stored at the third position `process.argv[2]`). To convert to an integer, you could use parseInt()
 
 Here is an example:
 


### PR DESCRIPTION
Previous exercise hint did not explicitly explain why we needed to know that `process.argv` is an array of strings

Now says this instead: 

```
To access the arguments you can use the `process.argv` array of strings (the first argument is stored at the third position `process.argv[2]`).
```

Issue: https://github.com/evanlucas/learnyoumongo/issues/23
